### PR TITLE
Bump commons-email in /maven-examples/maven-example/multi1

### DIFF
--- a/maven-examples/maven-example/multi1/pom.xml
+++ b/maven-examples/maven-example/multi1/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-email</artifactId>
-            <version>1.1</version>
+            <version>1.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bumps commons-email from 1.1 to 1.5.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-email dependency-type: direct:production ...